### PR TITLE
feat(demo): Add read kafka topic demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+.camel-jbang

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "redhat.vscode-kaoto",
+    "redhat.vscode-yaml",
+    "redhat.vscode-apache-camel",
+    "redhat.vscode-debug-adapter-apache-camel",
+    "redhat.vscode-camelk"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# kaoto-examples
+# Kaoto examples
 Hosting example integrations provided by users
+
+## Index
+| Name              | Description           | Tags          |
+| ---               | ---                   | ---           |
+| [kafkaToLog](kafka-to-log/kafka-to-log.camel.yaml)    | A camel route reading from a kafka topic and logging it to the screen | #kafka #log |

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,23 @@
+schemaVersion: 2.2.2
+metadata:
+  name: kaoto-examples
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      memoryLimit: 4G
+      cpuLimit: 4000m
+      cpuRequest: 1000m
+commands:
+  - id: jbang-trust-apache
+    exec:
+      label: "JBang - Trust Apache organization"
+      component: tools
+      workingDir: ${PROJECTS_ROOT}/kaoto-examples
+      commandLine: "jbang trust add https://github.com/apache/"
+      group:
+        kind: build
+        isDefault: true
+events:
+  postStart:
+    - jbang-trust-apache

--- a/kafka-to-log/README.md
+++ b/kafka-to-log/README.md
@@ -1,0 +1,37 @@
+# Read a Kafka topic
+
+This example shows how to read a Kafka topic, using the camel `kafka` component, and logs the messages to the console.
+
+## Prerequisites
+1. A running Kafka cluster
+2. A topic named `test-topic` with some messages in it
+
+## How to run
+1. Open the `kafka.camel.yaml` file and set the `brokers`, `topic` and `saslJaasConfig` values to match your Kafka cluster
+    1.1. This example uses the `SCRAM-SHA-256` SASL mechanism. If you are using a different mechanism, you need to change the `saslJaasConfig` value accordingly
+    1.2. This example expects to have a secret named `kafka-user-passwords` with a `client-passwords` key containing the password for the Kafka cluster
+2. Run the integration using the Camel CLI extension, or by executing the following command:
+```shell
+jbang '-Dcamel.jbang.version=4.5.0' camel@apache/camel run kafka.camel.yaml --dev --logging-level=info --local-kamelet-dir=.
+```
+
+## Parameters example
+You can pass the Kafka consumer parameters as plain values, environment variables or secrets. Here is an example of how to pass the parameters as plain values:
+```yaml
+parameters:
+    brokers: kafka-cluster-name:port
+    clientId: camel-route-client
+    saslJaasConfig: org.apache.kafka.common.security.scram.ScramLoginModule required username="user1" password="password";
+    saslMechanism: SCRAM-SHA-256
+    securityProtocol: SASL_PLAINTEXT
+```
+
+Here is an example of how to pass the parameters as secrets:
+```yaml
+parameters:
+    brokers: kafka-cluster-name:port
+    clientId: camel-route-client
+    saslJaasConfig: org.apache.kafka.common.security.scram.ScramLoginModule required username="user1" password="{{secret:kafka-user-passwords/client-passwords}}";
+    saslMechanism: SCRAM-SHA-256
+    securityProtocol: SASL_PLAINTEXT
+```

--- a/kafka-to-log/kafka-to-log.camel.yaml
+++ b/kafka-to-log/kafka-to-log.camel.yaml
@@ -1,0 +1,17 @@
+- route:
+    id: route-kafka
+    description: "Reads from a Kafka topic"
+    from:
+      id: from-kafka
+      uri: kafka:test-topic
+      parameters:
+        brokers: kafka.rm066rh-dev.svc.cluster.local:9092
+        clientId: camel-route-client
+        saslJaasConfig: org.apache.kafka.common.security.scram.ScramLoginModule required username="user1" password="{{secret:kafka-user-passwords/client-passwords}}";
+        saslMechanism: SCRAM-SHA-256
+        securityProtocol: SASL_PLAINTEXT
+      steps:
+        - to:
+            id: to-2210
+            uri: log:logger
+            parameters: {}


### PR DESCRIPTION
### Context
This PR adds an example of consuming messages from a Kafka topic.

In order to easily find the examples, a root README.md file was created to serve as an index of the examples, organized by tags, so we could find related examples from given technology easily.