### PR TITLE
feat(workshop): added file-monitor demo

### DIFF
--- a/file-monitor-workshop/README.md
+++ b/file-monitor-workshop/README.md
@@ -1,0 +1,34 @@
+# Demo: File Monitor Workshop
+
+## Purpose
+
+The purpose of this demo is to create a route that demonstrates the **File Integration Pattern** using the file-watch component to monitor file system events and automatically backup newly created files.
+
+## Prerequisites
+
+1. **Kaoto UI**: install Kaoto according to the instruction in the [installation guide](https://kaoto.io/docs/installation/)
+
+## Workflow
+
+1. **File Monitoring** ([`file-monitor.camel.yaml`](file-monitor.camel.yaml))
+   - Monitors the `/tmp/tutorial/` directory for file system events
+   - Filters for CREATE events (new files)
+   - Automatically copies newly created files to `/tmp/backup/` directory
+   - Logs all detected file events with timestamp
+
+## Running the Demo
+
+1. Run Kaoto UI and open the `file-monitor.camel.yaml` route
+
+2. Start the route by clicking the play icon
+
+3. Test the file monitor:
+   ```bash
+   # Create a test file in the monitored directory
+   echo "Test content" > /tmp/tutorial/test.txt
+   ```
+
+4. Monitor the output:
+   - Check the logs for the detected CREATE event
+   - Verify the file was copied to `/tmp/backup/` directory
+   - Try modifying or deleting files to see that only CREATE events trigger the backup

--- a/file-monitor-workshop/file-monitor.camel.yaml
+++ b/file-monitor-workshop/file-monitor.camel.yaml
@@ -1,0 +1,22 @@
+- route:
+    id: route-2573
+    from:
+      id: from-3280
+      uri: file-watch
+      parameters:
+        path: /tmp/tutorial/
+        recursive: false
+      steps:
+        - filter:
+            id: filter-2413
+            steps:
+              - to:
+                  id: to-2610
+                  uri: file
+                  parameters:
+                    directoryName: /tmp/backup/
+            simple:
+              expression: ${header.CamelFileEventType} == 'CREATE'
+        - log:
+            message: Detected ${header.CamelFileEventType} on file ${header.CamelFileName}
+              at ${header.CamelFileLastModified}


### PR DESCRIPTION
Adds the yaml for the file-monitor workshop

fix: https://github.com/KaotoIO/kaoto.io/issues/197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a workshop README with demo overview, prerequisites, and step‑by‑step instructions to run and observe the file monitoring workflow.

* **New Features**
  * Introduces a file-monitoring demo that detects newly created files, copies them to a backup location, and logs event details (event type, file name, timestamp) for easy verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->